### PR TITLE
Fix wrong name in typings.json

### DIFF
--- a/spec/typings.json
+++ b/spec/typings.json
@@ -1,5 +1,4 @@
 {
-  "name": "@akashic/akashic-cli-export-zip",
   "dependencies": {},
   "devDependencies": {},
   "globalDependencies": {

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,4 @@
 {
-  "name": "@akashic/akashic-cli-export-html",
   "dependencies": {},
   "devDependencies": {},
   "globalDependencies": {


### PR DESCRIPTION
## このpull requestが解決する内容

#1 を修正します。
akashic-cli-config などの例に倣い、単に name を削除します。
`npm install && npm run build && npm run test` が問題なくパスするのを確認済みです。修正そのものは自明のためセルフマージします。

## 破壊的な変更を含んでいるか?
なし