### PR TITLE
対象のコンテンツのスクリプトがes5構文に沿っているかを判定する処理の追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased changes
+* akashic-cli-commons@0.2.10 を利用するように
+* 対象のコンテンツのスクリプトがes5構文に沿っているかを判定する処理の追加
+
 ## 0.2.4
 * akashic-cli-commons@0.2.9 を利用するように
   * `--hash-filename` オプション有効時、 `moduleMainScripts` の値がおかしかった問題を修正。

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-cli-commons": "file:../akashic-cli-commons/akashic-akashic-cli-commons-0.2.9.tgz",
+    "@akashic/akashic-cli-commons": "~0.2.11",
     "archiver": "0.21.0",
     "browserify": "~10.2.4",
     "commander": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:ts": "npm run test:ts:compile && npm run test:ts:jasmine",
     "test:ts:compile": "npm run build && tsc -p ./spec",
     "test:ts:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js"
-},
+  },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
   "bin": {
@@ -54,7 +54,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-cli-commons": "~0.2.9",
+    "@akashic/akashic-cli-commons": "file:../akashic-cli-commons/akashic-akashic-cli-commons-0.2.9.tgz",
     "archiver": "0.21.0",
     "browserify": "~10.2.4",
     "commander": "2.8.1",

--- a/spec/fixtures/simple_game_es6/game.json
+++ b/spec/fixtures/simple_game_es6/game.json
@@ -1,0 +1,26 @@
+{
+	"width": 320,
+	"height": 320,
+	"fps": 30,
+	"main": "./script/main.js",
+	"assets": {
+		"main": {
+			"type": "script",
+			"path": "script/main.js",
+			"global": true
+		},
+		"bar": {
+			"type": "script",
+			"path": "script/bar.js",
+			"global": true
+		},
+		"foo": {
+			"type": "script",
+			"path": "script/foo.js",
+			"global": true
+		}
+	},
+	"environment": {
+		"sandbox-runtime": "2"
+	}
+}

--- a/spec/fixtures/simple_game_es6/script/bar.js
+++ b/spec/fixtures/simple_game_es6/script/bar.js
@@ -1,0 +1,3 @@
+module.exports = function (x) {
+	return x * 2;
+};

--- a/spec/fixtures/simple_game_es6/script/foo.js
+++ b/spec/fixtures/simple_game_es6/script/foo.js
@@ -1,0 +1,4 @@
+const bar = require("./bar");
+module.exports = () => {
+	return bar(100);
+};

--- a/spec/fixtures/simple_game_es6/script/main.js
+++ b/spec/fixtures/simple_game_es6/script/main.js
@@ -1,0 +1,9 @@
+const foo = require("./foo");
+
+const main = () => {
+	return {
+		x: foo()
+	};
+}
+
+module.exports = main;

--- a/spec/src/convertSpec.ts
+++ b/spec/src/convertSpec.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as mockfs from "mock-fs";
-import { bundleScripts } from "../../lib/convert";
+import { bundleScripts, convertGame } from "../../lib/convert";
 
 describe("convert", () => {
 
@@ -28,6 +28,23 @@ describe("convert", () => {
 
 					done();
 				}, done.fail);
+		});
+	});
+
+	describe("convertGame", () => {
+		it("can not convert game if script that is not written with ES5 syntax", (done) => {
+			const es6GameParameter = {
+				source: path.resolve(__dirname, "..", "fixtures", "simple_game_es6"),
+				dest: path.resolve(__dirname, "..", "fixtures", "simple_game_es6")
+			};
+			convertGame(es6GameParameter)
+				.then(() => {
+					done.fail();
+				})
+				.catch((e: any) => {
+					expect(e.message).toBe("The following files is not written with ES5 syntax. script/main.js, script/foo.js");
+					done();
+				});
 		});
 	});
 });

--- a/spec/src/convertSpec.ts
+++ b/spec/src/convertSpec.ts
@@ -42,7 +42,10 @@ describe("convert", () => {
 					done.fail();
 				})
 				.catch((e: any) => {
-					expect(e.message).toBe("The following files is not written with ES5 syntax. script/main.js, script/foo.js");
+					const expected = "The following ES5 syntax errors exist.\n"
+						+ "script/main.js(1:1): Parsing error: The keyword 'const' is reserved\n"
+						+ "script/foo.js(1:1): Parsing error: The keyword 'const' is reserved";
+					expect(e.message).toBe(expected);
 					done();
 				});
 		});

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -75,7 +75,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 				);
 			});
 			if (errorMessages.length > 0) {
-				throw new Error("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));
+				param.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));
 			}
 			const files = param.strip ? gcu.extractFilePaths(gamejson, param.source) : readdir(param.source);
 			files.forEach(p => {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -66,6 +66,14 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			gamejson = result;
 			cmn.Util.mkdirpSync(path.dirname(path.resolve(param.dest)));
 
+			// 全スクリプトがES5構文になっていることを確認する
+			const invalidFiles = gcu.extractScriptAssetFilePaths(gamejson).filter(filePath => {
+				const code = fs.readFileSync(path.resolve(param.source, filePath)).toString();
+				return !cmn.LintUtil.validateEs5Code(code);
+			});
+			if (invalidFiles.length > 0) {
+				throw new Error(`The following files is not written with ES5 syntax. ${invalidFiles.join(", ")}`);
+			}
 			const files = param.strip ? gcu.extractFilePaths(gamejson, param.source) : readdir(param.source);
 			files.forEach(p => {
 				cmn.Util.mkdirpSync(path.dirname(path.resolve(param.dest, p)));


### PR DESCRIPTION
### 概要
* ブラウザ上で動作させるため、akashicコンテンツはスクリプトはES5構文で書かれている必要があるが、スクリプトがそうなっているかを判定する機能が現状ないのでexport zip時に判定する処理を追加した。ES5構文で書かれていないスクリプトが含まれている場合はエラーをはいてexport zipを止めるようになっている

### やったこと
* export zip処理前にES5構文で書かれていないスクリプトが含まれていないかをチェックする処理の追加

### WIPを外す条件
* https://github.com/akashic-games/akashic-cli-commons/pull/17 がマージされて、その内容がpublishされること