### PR TITLE
Fix depreated function of archiver#bulk

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "package.json"
   ],
   "devDependencies": {
-    "@types/archiver": "~0.15.37",
+    "@types/archiver": "~2.1.2",
     "@types/browserify": "~12.0.33",
     "@types/commander": "~2.3.31",
     "@types/fs-extra": "^5.0.0",

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -45,16 +45,14 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 			return new Promise<void>((resolve, reject) => {
 				const files = readdir(destDir).map(p => ({
 					src: path.resolve(destDir, p),
-					dest: path.join("game", path.dirname(p)),
-					expand: true,
-					flatten: true
+					entryName: p
 				}));
 				const ostream = fs.createWriteStream(param.dest);
 				const archive = archiver("zip");
 				ostream.on("close", () => resolve());
 				archive.on("error", (err) => reject(err));
 				archive.pipe(ostream);
-				archive.bulk(files);
+				files.forEach((f) => archive.file(f.src, {name: f.entryName}));
 				archive.finalize();
 			});
 			// TODO mkdtempのフォルダを削除すべき？


### PR DESCRIPTION
### 概要

#21 で更新した `archiver:3.0.0` では、`bulk()`が削除されていた。(2.0.0で削除)
`@types/archiver` が古かったためビルドは通ったが、実行時にエラーとなっていた。

### 修正内容
- @types/archiverのversionを更新
- archive#bulk() の代わりに archive#file() を使用。([Archiver API Reference](https://archiverjs.com/docs/Archiver.html#file))