### PR TITLE
Add option no-omit-empty-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased
+* npm auditで警告がでているモジュールの更新
+  * モジュールの更新で `archiver#bulk()` が廃止されていたため `archiver#file()` に修正
+* 参照されないスクリプトアセットを非グローバル化
+
 ## 0.2.7
 * stripモードとbundleモードを同時に使うとエラーが発生してしまう問題の修正
 

--- a/spec/fixtures/simple_game_using_external/game.json
+++ b/spec/fixtures/simple_game_using_external/game.json
@@ -9,7 +9,7 @@
 			"path": "script/main.js",
 			"global": true
 		},
-		"ignore": {
+		"ignore2": {
 			"type": "script",
 			"path": "script/ignore.js",
 			"global": true

--- a/spec/fixtures/simple_game_using_external/game.json
+++ b/spec/fixtures/simple_game_using_external/game.json
@@ -9,6 +9,11 @@
 			"path": "script/main.js",
 			"global": true
 		},
+		"ignore": {
+			"type": "script",
+			"path": "script/ignore.js",
+			"global": true
+		},
 		"test": {
 			"type": "text",
 			"path": "text/test.json",

--- a/spec/fixtures/simple_game_using_external/script/ignore.js
+++ b/spec/fixtures/simple_game_using_external/script/ignore.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/spec/src/GameConfigurationUtilSpec.ts
+++ b/spec/src/GameConfigurationUtilSpec.ts
@@ -257,28 +257,49 @@ describe("GameConfigurationUtil", () => {
 		});
 	});
 
-	describe("isEmptyScriptJs", () => {
-		it("when buffer is empty true is returned", () => {
-			const ret = gcu.isEmptyScriptJs("script/test.js", new Buffer(""));
-			expect(ret).toBeTruthy();
-		});
-		it("when buffer isnt empty, false is returned", () => {
-			const ret = gcu.isEmptyScriptJs("script/test.js", new Buffer("aaaaaaaaaaa"));
-			expect(ret).toBeFalsy();
-		});
-		it("for interface logic only, true is returned", () => {
-			const buff = new Buffer("\"use strict\"\r\nObject.defineProperty(exports, \"__esModule\", { value: true });");
-			const ret = gcu.isEmptyScriptJs("script/hoge/test.js", buff);
-			expect(ret).toBeTruthy();
-		});
-		it("when typescript less then equal to 2.2.0 and interface logic only, true is returned,", () => {
-			const buff = new Buffer("\"use strict\";\r\n");
-			const ret = gcu.isEmptyScriptJs("script/hoge2/test.js", buff);
+	describe("isScriptJsFile", () => {
+		it("when filepath prefix is script, true is returned", () => {
+			const ret = gcu.isScriptJsFile("script/somewhere/test.js");
 			expect(ret).toBeTruthy();
 		});
 		it("when filepath prefix is not script, false is returned", () => {
-			const buff = new Buffer("aaaa\r\nbbb\rcccc");
-			const ret = gcu.isEmptyScriptJs("node_module/somewhere/test.js", buff);
+			const ret = gcu.isScriptJsFile("node_module/somewhere/test.js");
+			expect(ret).toBeFalsy();
+		});
+	});
+
+	describe("isEmptyScriptJs", () => {
+		it("when argument is empty true is returned", () => {
+			const ret = gcu.isEmptyScriptJs("");
+			expect(ret).toBeTruthy();
+		});
+		it("when argument isnt empty, false is returned", () => {
+			const ret = gcu.isEmptyScriptJs("aaaaaaaaaaa");
+			expect(ret).toBeFalsy();
+		});
+		it("For three or more lines", () => {
+			const ret = gcu.isEmptyScriptJs("\"use strict\";\r\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar test = 123;");
+			expect(ret).toBeFalsy();
+		});
+		it("for two lines", () => {
+			let ret = gcu.isEmptyScriptJs("\"use strict\";\r\nObject.defineProperty(exports, \"__esModule\", { value: true });");
+			expect(ret).toBeTruthy();
+
+			ret = gcu.isEmptyScriptJs("\"use strict\";\r\nObject.defineProperty(exports, \"__esModule\", { value: true });var hoge = 2;");
+			expect(ret).toBeFalsy();
+		});
+		it("for one line", () => {
+			let ret = gcu.isEmptyScriptJs("\"use strict\";");
+			expect(ret).toBeTruthy();
+			ret = gcu.isEmptyScriptJs("\"use strict\";var hoge=0;");
+			expect(ret).toBeFalsy();
+
+			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:!0});");
+			expect(ret).toBeTruthy();
+			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:true});");
+			expect(ret).toBeTruthy();
+
+			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:!0});var a=\"a\";");
 			expect(ret).toBeFalsy();
 		});
 	});

--- a/spec/src/GameConfigurationUtilSpec.ts
+++ b/spec/src/GameConfigurationUtilSpec.ts
@@ -256,4 +256,25 @@ describe("GameConfigurationUtil", () => {
 			expect(result).toBe("script/main1.js");
 		});
 	});
+
+	describe("isEmptyScriptJs", () => {
+		it("when buffer is empty true is returned", () => {
+			const ret = gcu.isEmptyScriptJs("script/test.js", new Buffer(""));
+			expect(ret).toBeTruthy();
+		});
+		it("when buffer isnt empty, false is returned", () => {
+			const ret = gcu.isEmptyScriptJs("script/test.js", new Buffer("aaaaaaaaaaa"));
+			expect(ret).toBeFalsy();
+		});
+		it("for interface logic only, true is returned", () => {
+			const buff = new Buffer("\"use strict\"\r\nObject.defineProperty(exports, \"__esModule\", { value: true });");
+			const ret = gcu.isEmptyScriptJs("script/hoge/test.js", buff);
+			expect(ret).toBeTruthy();
+		});
+		it("when filepath prefix is not script, false is returned", () => {
+			const buff = new Buffer("aaaa\r\nbbb\rcccc");
+			const ret = gcu.isEmptyScriptJs("node_module/somewhere/test.js", buff);
+			expect(ret).toBeFalsy();
+		});
+	});
 });

--- a/spec/src/GameConfigurationUtilSpec.ts
+++ b/spec/src/GameConfigurationUtilSpec.ts
@@ -271,6 +271,11 @@ describe("GameConfigurationUtil", () => {
 			const ret = gcu.isEmptyScriptJs("script/hoge/test.js", buff);
 			expect(ret).toBeTruthy();
 		});
+		it("when typescript less then equal to 2.2.0 and interface logic only, true is returned,", () => {
+			const buff = new Buffer("\"use strict\";\r\n");
+			const ret = gcu.isEmptyScriptJs("script/hoge2/test.js", buff);
+			expect(ret).toBeTruthy();
+		});
 		it("when filepath prefix is not script, false is returned", () => {
 			const buff = new Buffer("aaaa\r\nbbb\rcccc");
 			const ret = gcu.isEmptyScriptJs("node_module/somewhere/test.js", buff);

--- a/spec/src/convertSpec.ts
+++ b/spec/src/convertSpec.ts
@@ -109,7 +109,8 @@ describe("convert", () => {
 			const es6GameParameter = {
 				source: path.resolve(__dirname, "..", "fixtures", "simple_game_using_external"),
 				dest: destDir,
-				bundle: true
+				bundle: true,
+				omitEmptyJs: true
 			};
 			convertGame(es6GameParameter)
 				.then(() => {
@@ -180,7 +181,7 @@ describe("convert", () => {
 			const es6GameParameter = {
 				source: path.resolve(__dirname, "..", "fixtures", "simple_game_using_external"),
 				dest: destDir,
-				notSkipEmptyJs: true
+				omitEmptyJs: false
 			};
 			convertGame(es6GameParameter)
 				.then(() => {

--- a/spec/src/convertSpec.ts
+++ b/spec/src/convertSpec.ts
@@ -177,7 +177,7 @@ describe("convert", () => {
 					done();
 				}, done.fail);
 		});
-		it("Include empty files when in not-skip-empty-js mode", (done) => {
+		it("Include empty files when in no-omit-empty-js mode", (done) => {
 			const es6GameParameter = {
 				source: path.resolve(__dirname, "..", "fixtures", "simple_game_using_external"),
 				dest: destDir,

--- a/spec/src/convertSpec.ts
+++ b/spec/src/convertSpec.ts
@@ -79,6 +79,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/unrefered.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "script/ignore.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
@@ -96,6 +97,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/index.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "script/ignore.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/unrefered.js"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
@@ -115,6 +117,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "script/unrefered.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "script/ignore.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/aez_bundle_main.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
@@ -124,6 +127,7 @@ describe("convert", () => {
 					expect(gameJson.assets["aez_bundle_main"].path).toBe("script/aez_bundle_main.js");
 					expect(gameJson.assets["aez_bundle_main"].type).toBe("script");
 					expect(gameJson.assets["aez_bundle_main"].global).toBe(true);
+					expect(gameJson.assets["ignore"].global).toBeFalsy();
 					done();
 				}, done.fail);
 		});
@@ -139,6 +143,7 @@ describe("convert", () => {
 				.then(() => {
 					expect(fs.existsSync(path.join(outputDirectory, "script/unrefered.js"))).toBe(true);
 					expect(fs.existsSync(path.join(outputDirectory, "script/aez_bundle_main.js"))).toBe(true);
+					expect(fs.existsSync(path.join(outputDirectory, "script/ignore.js"))).toBe(true);
 					expect(fs.existsSync(path.join(outputDirectory, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(outputDirectory, "package.json"))).toBe(true);
 					expect(fs.existsSync(path.join(outputDirectory, "output"))).toBe(false);
@@ -160,6 +165,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/index.js"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBe(false);
+					expect(fs.existsSync(path.join(destDir, "script/ignore.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/unrefered.js"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "script/aez_bundle_main.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(false);
@@ -167,6 +173,28 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(false);
 					expect(fs.readFileSync(path.join(destDir, "game.json")).toString())
 						.not.toBe(fs.readFileSync(path.join(es6GameParameter.source, "game.json")).toString());
+					done();
+				}, done.fail);
+		});
+		it("Include empty files when in not-skip-empty-js mode", (done) => {
+			const es6GameParameter = {
+				source: path.resolve(__dirname, "..", "fixtures", "simple_game_using_external"),
+				dest: destDir,
+				notSkipEmptyJs: true
+			};
+			convertGame(es6GameParameter)
+				.then(() => {
+					expect(fs.existsSync(path.join(destDir, "node_modules/external/index.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "script/ignore.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "script/unrefered.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
+					const gameJson = fs.readFileSync(path.join(destDir, "game.json")).toString();
+					const gameJsonObj = JSON.parse(gameJson);
+					expect(gameJsonObj.assets["ignore"].global).toBeTruthy();
 					done();
 				}, done.fail);
 		});

--- a/spec/src/convertSpec.ts
+++ b/spec/src/convertSpec.ts
@@ -128,7 +128,7 @@ describe("convert", () => {
 					expect(gameJson.assets["aez_bundle_main"].path).toBe("script/aez_bundle_main.js");
 					expect(gameJson.assets["aez_bundle_main"].type).toBe("script");
 					expect(gameJson.assets["aez_bundle_main"].global).toBe(true);
-					expect(gameJson.assets["ignore"].global).toBeFalsy();
+					expect(gameJson.assets["ignore2"].global).toBeFalsy();
 					done();
 				}, done.fail);
 		});
@@ -195,7 +195,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
 					const gameJson = fs.readFileSync(path.join(destDir, "game.json")).toString();
 					const gameJsonObj = JSON.parse(gameJson);
-					expect(gameJsonObj.assets["ignore"].global).toBeTruthy();
+					expect(gameJsonObj.assets["ignore2"].global).toBeTruthy();
 					done();
 				}, done.fail);
 		});

--- a/src/GameConfigurationUtil.ts
+++ b/src/GameConfigurationUtil.ts
@@ -91,20 +91,24 @@ export function extractScriptAssetFilePaths(gamejson: cmn.GameConfiguration): st
 	return result;
 }
 
-export function isEmptyScriptJs(filePath: string, buff: Buffer): boolean {
-	if (!filePath.match(/^script\/.+(\.js$)/)) return false;
-	if (!buff || buff.length === 0 ) return true;
+export function isScriptJsFile(filePath: string): boolean {
+	return /^script\/.+(\.js$)/.test(filePath);
+}
 
-	const lines: string[] = buff.toString().trim().split(/\r\n|\r|\n/);
+export function isEmptyScriptJs(str: string): boolean {
+	if (!str || str.length === 0) return true;
+
+	const lines: string[] = str.toString().trim().split(/\r\n|\r|\n/);
 	// jsファイルの中身が、interfaceの記述のみの場合は空と同様とする
-	// TypeScirpt 2.2.0以下の場合、1行の出力のみとなる
-	if (lines.length === 1 && lines[0].match(/"use strict"/)) {
-		return true;
+	// TypeScirpt 2.2.0以下かminifyされた場合は1行の出力となる
+	if (lines.length === 1) {
+		return /"use strict";$/.test(lines[0]) ||
+			/"use strict";(Object.defineProperty\(exports,)\s*("__esModule",)\s*?({value\s*?:\s*?[true|!0]+}\));$/.test(lines[0]);
 
 	} else if (lines.length === 2) {
-		const firstLineResult = lines[0].match(/"use strict"/);
-		const secondLineResult = lines[1].match(/^(Object.defineProperty\(exports,).\s*("__esModule").\s*?({.value\s*?:\s*?true.\s*?})(\);+$)/);
-		return !!firstLineResult && !!secondLineResult;
+		const firstLineResult = /"use strict";$/.test(lines[0]);
+		const secondLineResult = /^(Object.defineProperty\(exports,).\s*("__esModule").\s*?({.value\s*?:\s*?true.\s*?})(\);+$)/.test(lines[1]);
+		return firstLineResult && secondLineResult;
 	}
 	return false;
 }

--- a/src/GameConfigurationUtil.ts
+++ b/src/GameConfigurationUtil.ts
@@ -91,3 +91,16 @@ export function extractScriptAssetFilePaths(gamejson: cmn.GameConfiguration): st
 	return result;
 }
 
+export function isEmptyScriptJs(filePath: string, buff: Buffer): boolean {
+	if (!filePath.match(/^script\/.+(\.js$)/)) return false;
+	if (!buff || buff.length === 0 ) return true;
+
+	const lines: string[] = buff.toString().trim().split(/\r\n|\r|\n/);
+	// jsファイルの中身が、interfaceの記述のみの場合は空と同様とする
+	if (filePath.match(/^script\/.+(\.[js]+$)/) && lines.length === 2) {
+		const firstLineResult = lines[0].match(/"use strict"/);
+		const secondLineResult = lines[1].match(/^(Object.defineProperty\(exports,).\s*("__esModule").\s*?({.value\s*?:\s*?true.\s*?})(\);+$)/);
+		return !!firstLineResult && !!secondLineResult;
+	}
+	return false;
+}

--- a/src/GameConfigurationUtil.ts
+++ b/src/GameConfigurationUtil.ts
@@ -97,7 +97,11 @@ export function isEmptyScriptJs(filePath: string, buff: Buffer): boolean {
 
 	const lines: string[] = buff.toString().trim().split(/\r\n|\r|\n/);
 	// jsファイルの中身が、interfaceの記述のみの場合は空と同様とする
-	if (filePath.match(/^script\/.+(\.[js]+$)/) && lines.length === 2) {
+	// TypeScirpt 2.2.0以下の場合、1行の出力のみとなる
+	if (lines.length === 1 && lines[0].match(/"use strict"/)) {
+		return true;
+
+	} else if (lines.length === 2) {
 		const firstLineResult = lines[0].match(/"use strict"/);
 		const secondLineResult = lines[1].match(/^(Object.defineProperty\(exports,).\s*("__esModule").\s*?({.value\s*?:\s*?true.\s*?})(\);+$)/);
 		return !!firstLineResult && !!secondLineResult;

--- a/src/GameConfigurationUtil.ts
+++ b/src/GameConfigurationUtil.ts
@@ -98,7 +98,8 @@ export function isScriptJsFile(filePath: string): boolean {
 export function isEmptyScriptJs(str: string): boolean {
 	if (!str || str.length === 0) return true;
 
-	// jsファイルの中身が、interfaceの記述のみの場合は空と同様とする
+	// jsファイルの中身が、Typescriptのinterfaceの記述のみの場合は空と同様とする
+	// TypeScirpt 2.2.0以下かminifyされた場合は、"use strict";だけの出力となる
 	const regex = /^"use strict";[\r\n\s]*(Object.defineProperty\(exports,\s*("__esModule",)\s*?({\s*?value\s*:\s*?[true|!0]+\s*})\);)*$/;
 	return regex.test(str.trim());
 }

--- a/src/GameConfigurationUtil.ts
+++ b/src/GameConfigurationUtil.ts
@@ -98,16 +98,7 @@ export function isScriptJsFile(filePath: string): boolean {
 export function isEmptyScriptJs(str: string): boolean {
 	if (!str || str.length === 0) return true;
 
-	const lines: string[] = str.toString().trim().split(/\r\n|\r|\n/);
 	// jsファイルの中身が、interfaceの記述のみの場合は空と同様とする
-	// TypeScirpt 2.2.0以下かminifyされた場合は1行の出力となる
-	if (lines.length === 1) {
-		return /"use strict";$/.test(lines[0]) ||
-			/"use strict";(Object.defineProperty\(exports,)\s*("__esModule",)\s*?({value\s*?:\s*?[true|!0]+}\));$/.test(lines[0]);
-	} else if (lines.length === 2) {
-		const firstLineResult = /"use strict";$/.test(lines[0]);
-		const secondLineResult = /^(Object.defineProperty\(exports,).\s*("__esModule").\s*?({.value\s*?:\s*?true.\s*?})(\);+$)/.test(lines[1]);
-		return firstLineResult && secondLineResult;
-	}
-	return false;
+	const regex = /^"use strict";[\r\n\s]*(Object.defineProperty\(exports,\s*("__esModule",)\s*?({\s*?value\s*:\s*?[true|!0]+\s*})\);)*$/;
+	return regex.test(str.trim());
 }

--- a/src/GameConfigurationUtil.ts
+++ b/src/GameConfigurationUtil.ts
@@ -104,7 +104,6 @@ export function isEmptyScriptJs(str: string): boolean {
 	if (lines.length === 1) {
 		return /"use strict";$/.test(lines[0]) ||
 			/"use strict";(Object.defineProperty\(exports,)\s*("__esModule",)\s*?({value\s*?:\s*?[true|!0]+}\));$/.test(lines[0]);
-
 	} else if (lines.length === 2) {
 		const firstLineResult = /"use strict";$/.test(lines[0]);
 		const secondLineResult = /^(Object.defineProperty\(exports,).\s*("__esModule").\s*?({.value\s*?:\s*?true.\s*?})(\);+$)/.test(lines[1]);

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -14,6 +14,7 @@ export interface ExportZipParameterObject {
 	dest?: string;
 	logger?: cmn.Logger;
 	hashLength?: number;
+	notSkipEmptyJs?: boolean;
 }
 
 export function _completeExportZipParameterObject(param: ExportZipParameterObject): void {
@@ -37,6 +38,7 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 		source: param.source,
 		dest: destDir,
 		hashLength: param.hashLength,
+		notSkipEmptyJs: param.notSkipEmptyJs,
 		logger: param.logger
 	})
 		.then(() => {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -14,7 +14,7 @@ export interface ExportZipParameterObject {
 	dest?: string;
 	logger?: cmn.Logger;
 	hashLength?: number;
-	notSkipEmptyJs?: boolean;
+	omitEmptyJs?: boolean;
 }
 
 export function _completeExportZipParameterObject(param: ExportZipParameterObject): void {
@@ -38,7 +38,7 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 		source: param.source,
 		dest: destDir,
 		hashLength: param.hashLength,
-		notSkipEmptyJs: param.notSkipEmptyJs,
+		omitEmptyJs: param.omitEmptyJs,
 		logger: param.logger
 	})
 		.then(() => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ interface CommandParameterObject {
 	minify?: boolean;
 	bundle?: boolean;
 	hashFilename?: number | boolean;
+	notSkipEmptyJs?: boolean;
 }
 
 
@@ -25,6 +26,7 @@ function cli(param: CommandParameterObject): void {
 			source: param.cwd,
 			dest: param.output,
 			hashLength: !param.hashFilename ? 0 : (param.hashFilename === true) ? 20 : Number(param.hashFilename),
+			notSkipEmptyJs: param.notSkipEmptyJs,
 			logger
 		}))
 		.catch((err: any) => {
@@ -46,7 +48,8 @@ commander
 	.option("-s, --strip", "Contain only files refered by game.json")
 	.option("-M, --minify", "Minify JavaScript files")
 	.option("-H, --hash-filename [length]", "Rename asset files with their hash values")
-	.option("-b, --bundle", "Bundle script assets into a single file");
+	.option("-b, --bundle", "Bundle script assets into a single file")
+	.option("-n, --not-skip-empty-js", "Do not skip empty js files");
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
@@ -57,6 +60,7 @@ export function run(argv: string[]): void {
 		strip: commander["strip"],
 		minify: commander["minify"],
 		hashFilename: commander["hashFilename"],
-		bundle: commander["bundle"]
+		bundle: commander["bundle"],
+		notSkipEmptyJs: commander["notSkipEmptyJs"]
 	});
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ interface CommandParameterObject {
 	minify?: boolean;
 	bundle?: boolean;
 	hashFilename?: number | boolean;
-	notSkipEmptyJs?: boolean;
+	omitEmptyJs?: boolean;
 }
 
 
@@ -26,7 +26,7 @@ function cli(param: CommandParameterObject): void {
 			source: param.cwd,
 			dest: param.output,
 			hashLength: !param.hashFilename ? 0 : (param.hashFilename === true) ? 20 : Number(param.hashFilename),
-			notSkipEmptyJs: param.notSkipEmptyJs,
+			omitEmptyJs: param.omitEmptyJs,
 			logger
 		}))
 		.catch((err: any) => {
@@ -49,7 +49,7 @@ commander
 	.option("-M, --minify", "Minify JavaScript files")
 	.option("-H, --hash-filename [length]", "Rename asset files with their hash values")
 	.option("-b, --bundle", "Bundle script assets into a single file")
-	.option("-n, --not-skip-empty-js", "Do not skip empty js files");
+	.option("--no-omit-empty-js", "Disable omitting empty js from global assets");
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
@@ -61,6 +61,6 @@ export function run(argv: string[]): void {
 		minify: commander["minify"],
 		hashFilename: commander["hashFilename"],
 		bundle: commander["bundle"],
-		notSkipEmptyJs: commander["notSkipEmptyJs"]
+		omitEmptyJs: commander["omitEmptyJs"]
 	});
 }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -95,9 +95,13 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					cmn.Util.mkdirpSync(path.dirname(path.resolve(param.dest, p)));
 					const buff = fs.readFileSync(path.resolve(param.source, p));
 
-					if (param.omitEmptyJs && gcu.isEmptyScriptJs(p, buff)) {
-						const fileName = path.basename(p).replace(/\.js$/, "");
-						gamejson.assets[fileName].global = false;
+					if (param.omitEmptyJs && gcu.isScriptJsFile(p) && gcu.isEmptyScriptJs(buff.toString().trim())) {
+						const target = Object.keys(gamejson.assets).find((key) => {
+							if (gamejson.assets[key].type !== "script") return false;
+							return gamejson.assets[key].path === p;
+						});
+						if (target)
+							gamejson.assets[target].global = false;
 					}
 					fs.writeFileSync(path.resolve(param.dest, p), buff);
 				}

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -14,6 +14,7 @@ export interface ConvertGameParameterObject {
 	source?: string;
 	hashLength?: number;
 	dest: string;
+	notSkipEmptyJs?: boolean;
 	/**
 	 * コマンドの出力を受け取るロガー。
 	 * 省略された場合、akashic-cli-commons の `new ConsoleLogger()` 。
@@ -28,6 +29,7 @@ export function _completeConvertGameParameterObject(param: ConvertGameParameterO
 	param.source = param.source || process.cwd();
 	param.hashLength = param.hashLength || 0;
 	param.logger = param.logger || new cmn.ConsoleLogger();
+	param.notSkipEmptyJs = !!param.notSkipEmptyJs;
 }
 
 export interface BundleResult {
@@ -91,7 +93,13 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			files.forEach(p => {
 				if (!noCopyingFilePaths.has(p)) {
 					cmn.Util.mkdirpSync(path.dirname(path.resolve(param.dest, p)));
-					fs.writeFileSync(path.resolve(param.dest, p), fs.readFileSync(path.resolve(param.source, p)));
+					const buff = fs.readFileSync(path.resolve(param.source, p));
+
+					if (!param.notSkipEmptyJs && gcu.isEmptyScriptJs(p, buff)) {
+						const fileName = path.basename(p).replace(/\.js$/, "");
+						gamejson.assets[fileName].global = false;
+					}
+					fs.writeFileSync(path.resolve(param.dest, p), buff);
 				}
 			});
 			if (bundleResult === null) {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -14,7 +14,7 @@ export interface ConvertGameParameterObject {
 	source?: string;
 	hashLength?: number;
 	dest: string;
-	notSkipEmptyJs?: boolean;
+	omitEmptyJs?: boolean;
 	/**
 	 * コマンドの出力を受け取るロガー。
 	 * 省略された場合、akashic-cli-commons の `new ConsoleLogger()` 。
@@ -29,7 +29,7 @@ export function _completeConvertGameParameterObject(param: ConvertGameParameterO
 	param.source = param.source || process.cwd();
 	param.hashLength = param.hashLength || 0;
 	param.logger = param.logger || new cmn.ConsoleLogger();
-	param.notSkipEmptyJs = !!param.notSkipEmptyJs;
+	param.omitEmptyJs = !!param.omitEmptyJs;
 }
 
 export interface BundleResult {
@@ -95,7 +95,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					cmn.Util.mkdirpSync(path.dirname(path.resolve(param.dest, p)));
 					const buff = fs.readFileSync(path.resolve(param.source, p));
 
-					if (!param.notSkipEmptyJs && gcu.isEmptyScriptJs(p, buff)) {
+					if (param.omitEmptyJs && gcu.isEmptyScriptJs(p, buff)) {
 						const fileName = path.basename(p).replace(/\.js$/, "");
 						gamejson.assets[fileName].global = false;
 					}

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -96,12 +96,13 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					const buff = fs.readFileSync(path.resolve(param.source, p));
 
 					if (param.omitEmptyJs && gcu.isScriptJsFile(p) && gcu.isEmptyScriptJs(buff.toString().trim())) {
-						const target = Object.keys(gamejson.assets).find((key) => {
-							if (gamejson.assets[key].type !== "script") return false;
-							return gamejson.assets[key].path === p;
+						Object.keys(gamejson.assets).some((key) => {
+							if (gamejson.assets[key].type === "script" && gamejson.assets[key].path === p) {
+								gamejson.assets[key].global = false;
+								return true;
+							}
+							return false;
 						});
-						if (target)
-							gamejson.assets[target].global = false;
 					}
 					fs.writeFileSync(path.resolve(param.dest, p), buff);
 				}


### PR DESCRIPTION
## このpull requestが解決する内容

以下の場合、参照されないスクリプトアセットのgame.jsonの `global` の値を`false`に変更する。
- jsファイルが空のファイル
- interface定義のみのファイル

また、上記を無効とするオプション `--no-omit-empty-js` を追加

**interface定義のみtsファイルをコンパイルすると以下の内容のjsファイルを出力する**
TypeScript 2.2.1以上
```
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
```
TypeScript 2.2.0以下では、`"use strict";` の1行のみの出力となる